### PR TITLE
Remove fedorasources.com tutorial (404 error)

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -35,7 +35,6 @@ Don't change the fixed id: there is a reference to here from the about page.
 ### Starting
 
 - There are good tutorials on the web:
-  - [http://fedoraresources.com/offlineimap.html](http://fedoraresources.com/offlineimap.html)
   - [https://wiki.archlinux.org/index.php/OfflineIMAP](https://wiki.archlinux.org/index.php/OfflineIMAP)
 - [Installation]({{ site.base }}/doc/installation.html)
 - [Quick Start]({{ site.base }}/doc/quick_start.html)

--- a/documentation.md
+++ b/documentation.md
@@ -35,7 +35,7 @@ Don't change the fixed id: there is a reference to here from the about page.
 ### Starting
 
 - There are good tutorials on the web:
-  - [Fedora Resources page on how to use offlineimap](https://web.archive.org/web/20170703235227/http://fedoraresources.com:80/offlineimap.html)
+  - [How to use offlineimap on Fedora](https://hobo.house/2015/09/09/take-control-of-your-email-with-mutt-offlineimap-notmuch/)
   - [https://wiki.archlinux.org/index.php/OfflineIMAP](https://wiki.archlinux.org/index.php/OfflineIMAP)
 - [Installation]({{ site.base }}/doc/installation.html)
 - [Quick Start]({{ site.base }}/doc/quick_start.html)

--- a/documentation.md
+++ b/documentation.md
@@ -35,6 +35,7 @@ Don't change the fixed id: there is a reference to here from the about page.
 ### Starting
 
 - There are good tutorials on the web:
+  - [Fedora Resources page on how to use offlineimap](https://web.archive.org/web/20170703235227/http://fedoraresources.com:80/offlineimap.html)
   - [https://wiki.archlinux.org/index.php/OfflineIMAP](https://wiki.archlinux.org/index.php/OfflineIMAP)
 - [Installation]({{ site.base }}/doc/installation.html)
 - [Quick Start]({{ site.base }}/doc/quick_start.html)


### PR DESCRIPTION
The fedorasources.com (FS) tutorial isn't available anymore and the domain now  redirects to a third party(?). There is still a [web.archive.org backup][1] though. Not sure whether you want to use this oppurtunity to include other tutorials, though. The FS tutorial seemed rather short.

 [1]: https://web.archive.org/web/20170830045154/http://fedoraresources.com/offlineimap.html